### PR TITLE
Fixed a bug in the previous commit.

### DIFF
--- a/execute_shell_commands.py
+++ b/execute_shell_commands.py
@@ -1,7 +1,3 @@
 import os
-# from formatting import pathname
-# from parameters import multi, test_mode, animate, seed, seed_list, N, l0, noise, noise_list, dt, t_total,\
-#                        stats_t_interval, U_two_interaction_weight, U_pressure_weight, allow_state_change, cenH_size,\
-#                        write_cenH_data, barriers, constant, constant_list, alpha_1, alpha_1_list, alpha_2, beta
 
-os.system(f"python3 main.py --multi=False --test_mode=False --t_total=1000 --stats_t_interval=1000 --cenH_size=2")
+os.system(f"python3 main.py --multi=1 --test_mode=0 --t_total=15000000 --stats_t_interval=1000 --cenH_size=3")

--- a/main.py
+++ b/main.py
@@ -57,7 +57,8 @@ if __name__ == '__main__':
             # data_file.close()
 
         # Create pool for multiprocessing
-        pool = Pool(cpu_count())
+        #pool = Pool(cpu_count())
+        pool = Pool(25)
 
         res = list(pool.map(curied_run, seed_list, chunksize=1))
 

--- a/parameters.py
+++ b/parameters.py
@@ -5,24 +5,24 @@ import argparse
 def get_parser_args():
     # Argparser from command line
     parser = argparse.ArgumentParser()
-    
+
     # Multiprocessing
     parser.add_argument('--multi',
-                        type=bool,
-                        default=False,
+                        type=int,
+                        default=0,
                         help='Use multiprocessing or not.')
 
     # Plots initial and final state, as well as statistics
     # Nothing (except possibly an animation) is saved
     parser.add_argument('--test_mode',
-                        type=bool,
-                        default=True,
+                        type=int,
+                        default=1,
                         help='If false, saves data. Else, nothing is saved, except possibly an animation.')
 
     # # Additionally generates and saves an animation
     parser.add_argument('--animate',
-                        type=bool,
-                        default=False,
+                        type=int,
+                        default=0,
                         help='If true, creates an animation.')
 
     # Random seed
@@ -89,14 +89,14 @@ def get_parser_args():
     ## State parameters
     # Allow states to change
     parser.add_argument('--allow_state_change',
-                        type=bool,
-                        default=True,
+                        type=int,
+                        default=1,
                         help='Enables the nucleosome states to change.')
 
     # Allow cell division
     parser.add_argument('--cell_division',
-                        type=bool,
-                        default=True,
+                        type=int,
+                        default=1,
                         help='Enables cell division.')
 
     # Include cenH region
@@ -106,14 +106,14 @@ def get_parser_args():
                         help='The size of the cenH region.')
 
     parser.add_argument('--write_cenH_data',
-                        type=bool,
-                        default=False,
+                        type=int,
+                        default=0,
                         help='Collects data on the spreading of the silent state.')
 
     # Include barriers
     parser.add_argument('--barriers',
-                        type=bool,
-                        default=False,
+                        type=int,
+                        default=0,
                         help='Includes system barriers.')
 
     # Constants


### PR DESCRIPTION
Changed the types of the boolean parsed arguments to integer values. Now a parsed argument like '--multi' must be an integer instead of a string (e.g. 'False'), as any string longer than 0 will be interpreted as the boolean value 'True'.